### PR TITLE
DTSPO-9049 - add tags to api mgmt resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,8 @@ resource "azurerm_subnet" "api-mgmt-subnet" {
   virtual_network_name = var.vnet_name
   address_prefixes     = ["${cidrsubnet(var.source_range, 4, 4)}"]
 
+  tags = var.common_tags
+
   lifecycle {
     ignore_changes = [address_prefix]
   }
@@ -22,6 +24,8 @@ resource "azurerm_api_management" "api-managment" {
   publisher_email           = var.publisher_email
   notification_sender_email = var.notification_sender_email
   virtual_network_type      = var.virtual_network_type
+
+  tags = var.common_tags
 
   virtual_network_configuration {
     subnet_id = azurerm_subnet.api-mgmt-subnet.id

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,6 @@ resource "azurerm_subnet" "api-mgmt-subnet" {
   virtual_network_name = var.vnet_name
   address_prefixes     = ["${cidrsubnet(var.source_range, 4, 4)}"]
 
-  tags = var.common_tags
-
   lifecycle {
     ignore_changes = [address_prefix]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -35,10 +35,3 @@ variable "common_tags" {
     "managedBy" = "pleaseTagMe"
   }
 }
-
-variable "common_tags" {
-  type = map(string)
-  default = {
-    "Team Name" = "pleaseTagMe"
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -35,3 +35,10 @@ variable "common_tags" {
     "managedBy" = "pleaseTagMe"
   }
 }
+
+variable "common_tags" {
+  type = map(string)
+  default = {
+    "Team Name" = "pleaseTagMe"
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9049


### Change description ###
Add tags to module
Absence of tags in api-mgmt resource is causing failures in the cnp-core-infrastructure pipeline as the resources do not meet policy requirements in non-prod environments

`Terraform command 'apply' failed with exit code '1'.:  creating/updating Custom Domain (API Management "core-api-mgmt-aat" / Resource Group "core-infra-aat"): apimanagement.ServiceClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="RequestDisallowedByPolicy" Message="Resource 'core-api-mgmt-aat' was disallowed by policy. Reasons: 'Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md'.`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
